### PR TITLE
Fix CUDA version in install.sh to be coherent with pyg wheels (cu 11.8)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ pip install plotly==5.9.0
 pip install "jupyterlab>=3" "ipywidgets>=7.6" jupyter-dash
 pip install "notebook>=5.3" "ipywidgets>=7.5"
 pip install ipykernel
-pip3 install torch torchvision
+pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu118
 pip install torchmetrics[detection]
 #pip install torch==1.12.0 torchvision
 pip install torch_geometric==2.3 pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.0.0+cu118.html

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ pip install plotly==5.9.0
 pip install "jupyterlab>=3" "ipywidgets>=7.6" jupyter-dash
 pip install "notebook>=5.3" "ipywidgets>=7.5"
 pip install ipykernel
-pip3 install torch torchvision --index-url https://download.pytorch.org/whl/cu118
+pip3 install torch==2.0.* torchvision --index-url https://download.pytorch.org/whl/cu118
 pip install torchmetrics[detection]
 #pip install torch==1.12.0 torchvision
 pip install torch_geometric==2.3 pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.0.0+cu118.html


### PR DESCRIPTION
Still need to test locally, hence the draft PR.

## What does this PR do?

This PR sets the index url when pip installin torch. This was necessary when installing the env in Google Collab, since torch would be installed with cuda 12.0 while pytorch geometric would be later installed wit cuda 11.8, resulting in an error message.

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
