### PR TITLE
fix: inverted precision/recall confusion matrices

### DIFF
--- a/src/metrics/confusion_matrix.py
+++ b/src/metrics/confusion_matrix.py
@@ -204,7 +204,7 @@ def save_confusion_matrix(cm, path2save, ordered_names):
         cm = cm.cpu().float().numpy()
 
     template_path = os.path.join(path2save, "{}.svg")
-    # PRECISION
+    # RECALL
     cmn = cm.astype("float") / cm.sum(axis=-1)[:, np.newaxis]
     cmn[np.isnan(cmn) | np.isinf(cmn)] = 0
     fig, ax = plt.subplots(figsize=(31, 31))
@@ -214,10 +214,10 @@ def save_confusion_matrix(cm, path2save, ordered_names):
     # g.set_xticklabels(g.get_xticklabels(), rotation = 35, fontsize = 20)
     plt.ylabel("Actual")
     plt.xlabel("Predicted")
-    path_precision = template_path.format("precision")
+    path_precision = template_path.format("recall")
     plt.savefig(path_precision, format="svg")
 
-    # RECALL
+    # PRECISION
     cmn = cm.astype("float") / cm.sum(axis=0)[np.newaxis, :]
     cmn[np.isnan(cmn) | np.isinf(cmn)] = 0
     fig, ax = plt.subplots(figsize=(31, 31))
@@ -227,5 +227,5 @@ def save_confusion_matrix(cm, path2save, ordered_names):
     # g.set_xticklabels(g.get_xticklabels(), rotation = 35, fontsize = 20)
     plt.ylabel("Actual")
     plt.xlabel("Predicted")
-    path_recall = template_path.format("recall")
+    path_recall = template_path.format("precision")
     plt.savefig(path_recall, format="svg")


### PR DESCRIPTION
## What does this PR do?

The labels "precision" and "recall" are I think inverted. The precision CM should be the one normalized by column: looking at the diagonal value gives the precision i.e. the % of predicted class that is from the actual class.

No tests needed since this is a smal small change I guess.

## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [NON] Did you **test your PR locally** with `pytest` command?
- [NON] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
