### PR TITLE
Use os.sep instead of hardcoded linux separator

### DIFF
--- a/src/datasets/base.py
+++ b/src/datasets/base.py
@@ -406,7 +406,7 @@ class BaseDataset(InMemoryDataset):
         """
         # Extract useful information from <path>
         stage, hash_dir, cloud_id = \
-            osp.splitext(processed_path)[0].split('/')[-3:]
+            osp.splitext(processed_path)[0].split(os.sep)[-3:]
 
         # Remove the tiling in the cloud_id, if any
         base_cloud_id = self.id_to_base_id(cloud_id)

--- a/src/datasets/dales.py
+++ b/src/datasets/dales.py
@@ -179,7 +179,7 @@ class DALES(BaseDataset):
         """
         # Extract useful information from <path>
         stage, hash_dir, cloud_id = \
-            osp.splitext(processed_path)[0].split('/')[-3:]
+            osp.splitext(processed_path)[0].split(os.sep)[-3:]
 
         # Raw 'val' and 'trainval' tiles are all located in the
         # 'raw/train/' directory

--- a/src/datasets/kitti360.py
+++ b/src/datasets/kitti360.py
@@ -179,8 +179,8 @@ class KITTI360(BaseDataset):
         """
         id = self.id_to_base_id(id)
         return osp.join(
-            'data_3d_semantics', id.split('/')[0], 'static',
-            id.split('/')[1] + '.ply')
+            'data_3d_semantics', id.split(os.sep)[0], 'static',
+            id.split(os.sep)[1] + '.ply')
 
     def processed_to_raw_path(self, processed_path):
         """Return the raw cloud path corresponding to the input
@@ -188,7 +188,7 @@ class KITTI360(BaseDataset):
         """
         # Extract useful information from <path>
         stage, hash_dir, sequence_name, cloud_id = \
-            osp.splitext(processed_path)[0].split('/')[-4:]
+            osp.splitext(processed_path)[0].split(os.sep)[-4:]
 
         # Remove the tiling in the cloud_id, if any
         base_cloud_id = self.id_to_base_id(cloud_id)
@@ -241,7 +241,7 @@ class KITTI360(BaseDataset):
         # windows and format those to match the expected file name:
         # {seq:0>4}_{start_frame:0>10}_{end_frame:0>10}.npy
         sequence_name, window_name = self.id_to_base_id(
-            self.cloud_ids[idx]).split('/')
+            self.cloud_ids[idx]).split(os.sep)
         seq = sequence_name.split('_')[-2]
         start_frame, end_frame = window_name.split('_')
         filename = f'{seq:0>4}_{start_frame:0>10}_{end_frame:0>10}.npy'

--- a/src/datasets/s3dis_room.py
+++ b/src/datasets/s3dis_room.py
@@ -1,6 +1,9 @@
 import torch
 import logging
 import pandas as pd
+import os.path as osp
+import os
+
 from src.utils.geometry import rodrigues_rotation_matrix
 from src.datasets.s3dis_config import *
 from src.datasets.s3dis import read_s3dis_room, S3DIS
@@ -83,7 +86,7 @@ class S3DISRoom(S3DIS):
         """
         # Extract useful information from <path>
         stage, hash_dir, area_id, room_id = \
-            osp.splitext(processed_path)[0].split('/')[-4:]
+            osp.splitext(processed_path)[0].split(os.sep)[-4:]
         cloud_id = osp.join(area_id, room_id)
 
         # Remove the tiling in the cloud_id, if any


### PR DESCRIPTION
## What does this PR do?
It makes SPT training work on windows by replacing calls to `str.split('/')` by `str.split(os.sep)`. It corrects a missing import too.


## Before submitting

- [X] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [X] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
Apart the missing imports, yes
- [X] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
Tested on a modified code base of SPT, but not on the upstream repo but it should be harmless 
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?
moderatly