### PR TITLE
fix metric calculation with multiple GPUs for semantic segmentation

### DIFF
--- a/src/models/semantic.py
+++ b/src/models/semantic.py
@@ -635,16 +635,26 @@ class SemanticSegmentationModule(LightningModule):
             prog_bar=True)
 
     def on_train_epoch_end(self) -> None:
-        # Log metrics
-        self.log("train/miou", self.train_cm.miou(), prog_bar=True)
-        self.log("train/oa", self.train_cm.oa(), prog_bar=True)
-        self.log("train/macc", self.train_cm.macc(), prog_bar=True)
-        for iou, seen, name in zip(*self.train_cm.iou(), self.class_names):
-            if seen:
-                self.log(f"train/iou_{name}", iou, prog_bar=True)
+
+        if self.trainer.num_devices > 1:
+            epoch_cm = torch.sum(self.all_gather(self.train_cm.confmat), dim=0)
+        else:
+            epoch_cm = self.train_cm
 
         # Reset metrics accumulated over the last epoch
         self.train_cm.reset()
+
+        epoch_cm = ConfusionMatrix(self.num_classes).from_confusion_matrix(epoch_cm)
+
+        # Log metrics
+        self.log("train/miou", epoch_cm.miou(), prog_bar=True, rank_zero_only=True)
+        self.log("train/oa", epoch_cm.oa(), prog_bar=True, rank_zero_only=True)
+        self.log("train/macc", epoch_cm.macc(), prog_bar=True, rank_zero_only=True)
+        for iou, seen, name in zip(*epoch_cm.iou(), self.class_names):
+            if seen:
+                self.log(f"train/iou_{name}", iou, prog_bar=True, rank_zero_only=True)
+
+        del epoch_cm
 
     def validation_step(
             self,
@@ -700,33 +710,42 @@ class SemanticSegmentationModule(LightningModule):
             "val/loss", self.val_loss, on_step=False, on_epoch=True,
             prog_bar=True)
 
-    def on_validation_epoch_end(self) -> None:
-        miou = self.val_cm.miou()
-        oa = self.val_cm.oa()
-        macc = self.val_cm.macc()
+    def on_validation_epoch_end(self):
 
-        # Log metrics
-        self.log("val/miou", miou, prog_bar=True)
-        self.log("val/oa", oa, prog_bar=True)
-        self.log("val/macc", macc, prog_bar=True)
-        for iou, seen, name in zip(*self.val_cm.iou(), self.class_names):
-            if seen:
-                self.log(f"val/iou_{name}", iou, prog_bar=True)
+        if self.trainer.num_devices > 1:
+            epoch_cm = torch.sum(self.all_gather(self.val_cm.confmat), dim=0)
+        else:
+            epoch_cm = self.val_cm
+        # Reset metrics accumulated over the last epoch
+        self.val_cm.reset()
+
+        epoch_cm = ConfusionMatrix(self.num_classes).from_confusion_matrix(epoch_cm)
+
+        miou = epoch_cm.miou()
+        oa = epoch_cm.oa()
+        macc = epoch_cm.macc()
 
         # Update best-so-far metrics
         self.val_miou_best(miou)
         self.val_oa_best(oa)
         self.val_macc_best(macc)
 
+        # Log metrics
+        self.log("val/miou", miou, prog_bar=True, rank_zero_only=True)
+        self.log("val/oa", oa, prog_bar=True, rank_zero_only=True)
+        self.log("val/macc", macc, prog_bar=True, rank_zero_only=True)
+        for iou, seen, name in zip(*epoch_cm.iou(), self.class_names):
+            if seen:
+                self.log(f"val/iou_{name}", iou, prog_bar=True, rank_zero_only=True)
+
         # Log best-so-far metrics, using `.compute()` instead of passing
         # the whole torchmetrics object, because otherwise metric would
         # be reset by lightning after each epoch
-        self.log("val/miou_best", self.val_miou_best.compute(), prog_bar=True)
-        self.log("val/oa_best", self.val_oa_best.compute(), prog_bar=True)
-        self.log("val/macc_best", self.val_macc_best.compute(), prog_bar=True)
+        self.log("val/miou_best", self.val_miou_best.compute(), prog_bar=True, rank_zero_only=True)
+        self.log("val/oa_best", self.val_oa_best.compute(), prog_bar=True, rank_zero_only=True)
+        self.log("val/macc_best", self.val_macc_best.compute(), prog_bar=True, rank_zero_only=True)
 
-        # Reset metrics accumulated over the last epoch
-        self.val_cm.reset()
+        del epoch_cm
 
     def on_test_start(self) -> None:
         # Initialize the submission directory based on the time of the
@@ -806,7 +825,7 @@ class SemanticSegmentationModule(LightningModule):
             "test/loss", self.test_loss, on_step=False, on_epoch=True,
             prog_bar=True)
 
-    def on_test_epoch_end(self) -> None:
+    def on_test_epoch_end(self):
         # Finalize the submission
         if self.trainer.datamodule.hparams.submit:
             self.trainer.datamodule.test_dataset.finalize_submission(
@@ -817,22 +836,30 @@ class SemanticSegmentationModule(LightningModule):
             self.test_cm.reset()
             return
 
+        if self.trainer.num_devices > 1:
+            epoch_cm = torch.sum(self.all_gather(self.test_cm.confmat), dim=0)
+        else:
+            epoch_cm = self.test_cm
+        # Reset metrics accumulated over the last epoch
+        self.test_cm.reset()
+
+        epoch_cm = ConfusionMatrix(self.num_classes).from_confusion_matrix(epoch_cm)
+
         # Log metrics
-        self.log("test/miou", self.test_cm.miou(), prog_bar=True)
-        self.log("test/oa", self.test_cm.oa(), prog_bar=True)
-        self.log("test/macc", self.test_cm.macc(), prog_bar=True)
-        for iou, seen, name in zip(*self.test_cm.iou(), self.class_names):
+        self.log("test/miou", epoch_cm.miou(), prog_bar=True, rank_zero_only=True)
+        self.log("test/oa", epoch_cm.oa(), prog_bar=True, rank_zero_only=True)
+        self.log("test/macc", epoch_cm.macc(), prog_bar=True, rank_zero_only=True)
+        for iou, seen, name in zip(*epoch_cm.iou(), self.class_names):
             if seen:
-                self.log(f"test/iou_{name}", iou, prog_bar=True)
+                self.log(f"test/iou_{name}", iou, prog_bar=True, rank_zero_only=True)
 
         # Log confusion matrix to wandb
         if isinstance(self.logger, WandbLogger):
             self.logger.experiment.log({
                 "test/cm": wandb_confusion_matrix(
-                    self.test_cm.confmat, class_names=self.class_names)})
+                    epoch_cm.confmat, class_names=self.class_names)})
 
-        # Reset metrics accumulated over the last epoch
-        self.test_cm.reset()
+        del epoch_cm
 
     def predict_step(
             self,


### PR DESCRIPTION
## What does this PR do?

This PR gathers the confusion matrix computed on the unique mini-batch assigned to each GPU when training with DDP and then calculates the metrics based on the updated confusion matrix. 

Fixes #165 

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
