### PR TITLE
fix: `val/points_per_superpoint` metric no longer broken

### DIFF
--- a/src/models/semantic.py
+++ b/src/models/semantic.py
@@ -1627,7 +1627,11 @@ class PartitionAndSemanticModule(SemanticSegmentationModule):
             n_sp = self.val_n_sp.compute()
             if n_sp > 0:
                 self.log("val/points_per_superpoint", n_p / n_sp, prog_bar=True)
-
+            
+            # Since `val_n_p` is not logged, it needs to be manually reset
+            self.val_n_p.reset()
+            self.val_n_sp.reset()
+            
     def test_step_update_metrics(self, loss, output) -> None:
         if not self.training_partition_stage:
             return super().test_step_update_metrics(loss, output)
@@ -1675,6 +1679,9 @@ class PartitionAndSemanticModule(SemanticSegmentationModule):
             n_sp = self.test_n_sp.compute()
             if n_sp > 0:
                 self.log("test/points_per_superpoint", n_p / n_sp, prog_bar=True)
+
+            self.test_n_p.reset()
+            self.test_n_sp.reset()
 
     def _load_from_checkpoint(
             self,


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

The number of points `n_p` was accumulated across epochs, leading to incorrect values in the  `val/points_per_superpoint` metric. 

Since `n_p` is not logged during partition learning, it must be manually reset at the end of each epoch.


## Before submitting

- [x] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [x] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃