### PR TITLE
Minor refactor in `on_fit_start`

### DIFF
--- a/configs/model/partition/default_ezsp.yaml
+++ b/configs/model/partition/default_ezsp.yaml
@@ -7,8 +7,6 @@ _target_: src.models.semantic.PartitionAndSemanticModule
 
 training_partition_stage: True
 
-multi_stage_loss_lambdas: null
-loss_type: null
 
 # This creates the following CNN : dim_hf -> 32 -> 32 -> 32
 # where each arrow (->) is a convolutional block. (Conv -> GN -> LeakyReLU)
@@ -35,6 +33,13 @@ partition:
   verbose: ${datamodule.contour_prior_verbose}
   sharding: ${datamodule.contour_prior_sharding}
 
+# Disable everything related to the semantic criterion
+multi_stage_loss_lambdas: null
+loss_type: null
+weighted_loss: False
+
+# Criterion for partition training is saved under the `partition_criterion` 
+# attribute.
 partition_criterion:
   _target_: src.loss.partition_criterion.PartitionCriterion
   

--- a/src/models/semantic.py
+++ b/src/models/semantic.py
@@ -323,6 +323,16 @@ class SemanticSegmentationModule(LightningModule):
             f'LightningDataModule has {num_classes} classes.'
 
         self.class_names = dataset.class_names
+        
+        # Check that the period of track_val_every_n_epoch` is a
+        # multiple of check_val_every_n_epoch
+        if self.trainer.check_val_every_n_epoch is not None:
+            assert (self.hparams.track_val_every_n_epoch
+                    % self.trainer.check_val_every_n_epoch == 0), \
+                (f"Expected 'track_val_every_n_epoch' to be a multiple of "
+                 f"'check_val_every_n_epoch', but received "
+                 f"{self.hparams.track_val_every_n_epoch} and "
+                 f"{self.trainer.check_val_every_n_epoch} instead.")
 
         if not self.hparams.weighted_loss:
             return
@@ -338,16 +348,6 @@ class SemanticSegmentationModule(LightningModule):
             weight = self.trainer.datamodule.train_dataset.get_class_weight(
                 smooth=getattr(self.hparams, 'weighted_loss_smooth', 'sqrt'))
             self.criterion.weight = weight.to(self.device)
-
-        # Check that the period of track_val_every_n_epoch` is a
-        # multiple of check_val_every_n_epoch
-        if self.trainer.check_val_every_n_epoch is not None:
-            assert (self.hparams.track_val_every_n_epoch
-                    % self.trainer.check_val_every_n_epoch == 0), \
-                (f"Expected 'track_val_every_n_epoch' to be a multiple of "
-                 f"'check_val_every_n_epoch', but received "
-                 f"{self.hparams.track_val_every_n_epoch} and "
-                 f"{self.trainer.check_val_every_n_epoch} instead.")
 
     def on_train_start(self) -> None:
         # By default, lightning executes validation step sanity checks


### PR DESCRIPTION
## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
List all the breaking changes introduced by this pull request.
-->

This PR introduces minor refactoring without changing any current behavior:
1. Moved an assertion to the start of on_fit_start to always execute. 
    - Previously, it was not executed when `self.hparams.weighted_loss=False` 


2. In partition training configs, switched `weighted_loss` from `True` to `False`. 
    - Previously, the weights per semantic class were computed. However, they are not used during partition training.